### PR TITLE
Fixed a height bug in Poisson mode for Terrains with offset y position

### DIFF
--- a/Assets/Yapp/Editor/Modules/BrushModuleEditor.cs
+++ b/Assets/Yapp/Editor/Modules/BrushModuleEditor.cs
@@ -352,8 +352,8 @@ namespace Yapp
                 // y depends on the terrain height
                 Vector3 terrainPosition = new Vector3(x, position.y, z);
 
-                // get terrain y position
-                float y = Terrain.activeTerrain.SampleHeight(terrainPosition);
+                // get terrain y position and add Terrain Transform Y-Position
+                float y = Terrain.activeTerrain.SampleHeight(terrainPosition) + Terrain.activeTerrain.GetPosition().y;
 
                 // create position vector
                 Vector3 prefabPosition = new Vector3( x, y, z);


### PR DESCRIPTION
The height was sampled but this lost the Transform Y-Position.

See https://forum.unity.com/threads/free-yapp-yet-another-prefab-painter-open-source-github.782483/page-2#post-6692251